### PR TITLE
HSTS Fixes

### DIFF
--- a/Garmr/corechecks.py
+++ b/Garmr/corechecks.py
@@ -50,6 +50,18 @@ class StrictTransportSecurityPresent(PassiveTest):
             result = self.result("Pass", "Strict-Transport-Security header present.", response.headers[stsheader])
         return result
 
+class StrictTransportSecurityIncludeSubDomainsPresent(PassiveTest):
+    secure_only = True
+    description = "Check if the Strict-Transport-Security includeSubDomains header option is present in TLS requests."
+    def analyze(self, response):
+        stsheader = "includeSubDomains"
+        sts = stsheader in response.headers
+        if sts == False:
+            result = self.result("Fail", "Strict-Transport-Security header not found.", None)
+        else:
+            result = self.result("Pass", "Strict-Transport-Security header present.", response.headers[stsheader])
+        return result
+
 class XFrameOptionsPresent(PassiveTest):
     description = "Check if X-Frame-Options header is present."
     def analyze(self, response):

--- a/Garmr/scanner.py
+++ b/Garmr/scanner.py
@@ -74,7 +74,9 @@ class ActiveTest():
     def execute(self, url, predecessor=None):
         self.url = url
         if self.url not in self.sessions or self.new_session:
-            self.sessions[url] = requests.session() # Create per-target session
+            sess = requests.session() # Create per-target session
+            sess.headers.update({'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:31.0) Gecko/20100101 Firefox/31.0'})
+            self.sessions[url] = sess
         try:
             if "pred" in getargspec(self.do_test).args:
                 resulttuple = self.do_test(url, predecessor)


### PR DESCRIPTION
On some sites, such as facebook.com, the HSTS header is only set when it gets a request from a browser that has implemented HSTS. Therefore, in order to perform a valid check, Garmr needs to set the User-Agent request header to be a modern web browser, such as the latest version of Firefox. I've set this value in the requests session.

I've also added 2 additional checks to the HSTS check to validate the max-age is long enough and to validate that the includeSubDomains directive is included. For information on why this is important, see the HSTS spec here: http://tools.ietf.org/html/rfc6797 and a proof of concept for SSL Strip with non-protected sites here: https://www.youtube.com/watch?v=uGBjxfizy48
